### PR TITLE
feat: add module with perun rpc api library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,13 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 /target/
+
+# Ignore IntelliJ project files #
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# Ignore Maven target #
+**/target
+dependency-reduced-pom.xml

--- a/connector-perun-rpc/pom.xml
+++ b/connector-perun-rpc/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <groupId>com.evolveum.polygon</groupId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <artifactId>connector-perun-rpc</artifactId>
+
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>16</maven.compiler.source>
+        <maven.compiler.target>16</maven.compiler.target>
+    </properties>
+
+    <build>
+        <plugins>
+            <!-- generate a Java client from OpenAPI specification of Perun RPC API-->
+            <plugin>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <version>5.2.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <!-- see https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator-maven-plugin/README.md -->
+                            <inputSpec>https://raw.githubusercontent.com/CESNET/perun/master/perun-openapi/openapi.yml</inputSpec>
+                            <generatorName>java</generatorName>
+                            <apiPackage>cz.metacentrum.perun.polygon.connector.rpc.openapi</apiPackage>
+                            <modelPackage>cz.metacentrum.perun.polygon.connector.rpc.openapi.model</modelPackage>
+                            <invokerPackage>cz.metacentrum.perun.polygon.connector.rpc.openapi.invoker</invokerPackage>
+                            <verbose>false</verbose>
+                            <generateApiTests>false</generateApiTests>
+                            <generateModelTests>false</generateModelTests>
+                            <generateApiDocumentation>false</generateApiDocumentation>
+                            <generateModelDocumentation>false</generateModelDocumentation>
+                            <configOptions>
+                                <dateLibrary>java8</dateLibrary>
+                                <library>resttemplate</library>
+                                <java8>true</java8>
+                                <!-- options for generating target/generated-sources/openapi/pom.xml which is not used -->
+                                <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
+                                <licenseName>Apache 2.0</licenseName>
+                                <groupId>com.evolveum.polygon</groupId>
+                                <artifactId>connector-parent</artifactId>
+                                <artifactVersion>0.0.1-SNAPSHOT</artifactVersion>
+                                <artifactDescription>Perun RPC API in Java</artifactDescription>
+                                <scmUrl>https://github.com/CESNET/perun</scmUrl>
+                            </configOptions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>5.3.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>5.3.9</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.12.5</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>1.6.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>0.2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>4.4.14</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/connector-perun-rpc/src/main/java/cz/metacentrum/perun/polygon/connector/rpc/openapi/PerunException.java
+++ b/connector-perun-rpc/src/main/java/cz/metacentrum/perun/polygon/connector/rpc/openapi/PerunException.java
@@ -1,0 +1,54 @@
+package cz.metacentrum.perun.polygon.connector.rpc.openapi;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.web.client.HttpClientErrorException;
+
+import java.io.IOException;
+
+public class PerunException extends Exception {
+
+    private String errorId;
+    private String name;
+
+    private PerunException(String message, Throwable cause, String name, String errorId) {
+        super(message, cause);
+        this.name = name;
+        this.errorId = errorId;
+    }
+
+    /**
+     * Converts JSON responseBody of HttpClientErrorException to PerunException.
+     *
+     * @param ex HttpClientErrorException containing
+     * @return PerunException
+     */
+    public static PerunException to(HttpClientErrorException ex) {
+        try {
+            cz.metacentrum.perun.polygon.connector.rpc.openapi.model.PerunException pe = new ObjectMapper()
+                    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                    .readValue(ex.getResponseBodyAsByteArray(), cz.metacentrum.perun.polygon.connector.rpc.openapi.model.PerunException.class);
+            return new PerunException(pe.getName() + ": " + pe.getMessage(), ex, pe.getName(), pe.getErrorId());
+        } catch (IOException ioe) {
+            return new PerunException("cannot parse remote Exception", ex, "", "");
+        }
+    }
+
+    /**
+     * Gets the unique Perun id of the exception.
+     *
+     * @return id
+     */
+    public String getErrorId() {
+        return errorId;
+    }
+
+    /**
+     * Gets the name of the remote exception. E.g. " GroupNotExistsException".
+     *
+     * @return simple class name of remote exception
+     */
+    public String getName() {
+        return name;
+    }
+}

--- a/connector-perun-rpc/src/main/java/cz/metacentrum/perun/polygon/connector/rpc/openapi/PerunRPC.java
+++ b/connector-perun-rpc/src/main/java/cz/metacentrum/perun/polygon/connector/rpc/openapi/PerunRPC.java
@@ -1,0 +1,159 @@
+package cz.metacentrum.perun.polygon.connector.rpc.openapi;
+
+import cz.metacentrum.perun.polygon.connector.rpc.openapi.invoker.ApiClient;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Main Perun RPC client class. Uses ApiClient and model generated from OpenAPI description of Perun RPC API.
+ * The ApiClient pools HTTP connections and keeps cookies.
+ * Use it like this:
+ * <pre>
+ *     PerunRPC perunRPC = new PerunRPC(PerunRPC.PERUN_URL_CESNET, user, password);
+ *     try {
+ *        Group group = perunRPC.getGroupsManager().getGroupById(1);
+ *     } catch (HttpClientErrorException ex) {
+ *         throw PerunException.to(ex);
+ *     } catch (RestClientException ex) {
+ *        log.error("connection problem",ex);
+ *     }
+ * </pre>
+ *
+ * @author Martin Kuba makub@ics.muni.cz
+ */
+public class PerunRPC {
+
+    final private ApiClient apiClient;
+
+    final private AttributesManagerApi attributesManager;
+    final private AuthzResolverApi authzResolver;
+    final private DatabaseManagerApi databaseManager;
+    final private ExtSourcesManagerApi extSourcesManager;
+    final private FacilitiesManagerApi facilitiesManager;
+    final private GroupsManagerApi groupsManager;
+    final private MembersManagerApi membersManager;
+    final private OwnersManagerApi ownersManager;
+    final private RegistrarManagerApi registrarManager;
+    final private ResourcesManagerApi resourcesManager;
+    final private UsersManagerApi usersManager;
+    final private UtilsApi utils;
+    final private VosManagerApi vosManager;
+    final private ServicesManagerApi servicesManager;
+
+    public PerunRPC(RestTemplate restTemplate) {
+        if (restTemplate == null) {
+            restTemplate = new RestTemplate(new HttpComponentsClientHttpRequestFactory());
+        }
+        //HTTP connection pooling and cookie reuse (PerunSession is created only for the first request)
+        apiClient = new ApiClient(restTemplate);
+        apiClient.setUserAgent("Perun OpenAPI Java client");
+        //all the managers share the ApiClient and thus the connection pool and cookies
+        attributesManager = new AttributesManagerApi(apiClient);
+        authzResolver = new AuthzResolverApi(apiClient);
+        databaseManager = new DatabaseManagerApi(apiClient);
+        extSourcesManager = new ExtSourcesManagerApi(apiClient);
+        facilitiesManager = new FacilitiesManagerApi(apiClient);
+        groupsManager = new GroupsManagerApi(apiClient);
+        membersManager = new MembersManagerApi(apiClient);
+        ownersManager = new OwnersManagerApi(apiClient);
+        registrarManager = new RegistrarManagerApi(apiClient);
+        resourcesManager = new ResourcesManagerApi(apiClient);
+        usersManager = new UsersManagerApi(apiClient);
+        utils = new UtilsApi(apiClient);
+        vosManager = new VosManagerApi(apiClient);
+        servicesManager = new ServicesManagerApi(apiClient);
+    }
+
+    public PerunRPC() {
+        this(null);
+    }
+
+    public PerunRPC(String perunURL, String username, String password, RestTemplate restTemplate) {
+        this(restTemplate);
+        apiClient.setBasePath(perunURL);
+        apiClient.setUsername(username);
+        apiClient.setPassword(password);
+    }
+
+    /**
+     * Sets base path and credentials for HTTP basic authentication
+     *
+     * @param perunURL URL up to the "rpc" part, e.g. https://perun-dev.cesnet.cz/krb/rpc-joe
+     * @param username for BasicAuth
+     * @param password for BasicAuth
+     */
+    public PerunRPC(String perunURL, String username, String password) {
+        this(perunURL, username, password, null);
+    }
+
+    /**
+     * Provides generated ApiClient. It is initialized with RestTemplate and HttpComponentsClientHttpRequestFactory.
+     * The ApiClient can be used for:
+     * <ul>
+     *     <li>setting authentication using e.g. <code>getApiClient().setBearerToken(token);</code></li>
+     *     <li>setting base path e.g. <code>getApiClient().setBasePath("https://perun.example.org/oidc");</code></li>
+     *     <li>setting user agent header, e.g. <code>getApiClient().setUserAgent("My application")</code></li>
+     * </ul>.
+     *
+     * @return ApiClient
+     */
+    public ApiClient getApiClient() {
+        return apiClient;
+    }
+
+    public AttributesManagerApi getAttributesManager() {
+        return attributesManager;
+    }
+
+    public AuthzResolverApi getAuthzResolver() {
+        return authzResolver;
+    }
+
+    public DatabaseManagerApi getDatabaseManager() {
+        return databaseManager;
+    }
+
+    public ExtSourcesManagerApi getExtSourcesManager() {
+        return extSourcesManager;
+    }
+
+    public FacilitiesManagerApi getFacilitiesManager() {
+        return facilitiesManager;
+    }
+
+    public GroupsManagerApi getGroupsManager() {
+        return groupsManager;
+    }
+
+    public MembersManagerApi getMembersManager() {
+        return membersManager;
+    }
+
+    public OwnersManagerApi getOwnersManager() {
+        return ownersManager;
+    }
+
+    public RegistrarManagerApi getRegistrarManager() {
+        return registrarManager;
+    }
+
+    public ResourcesManagerApi getResourcesManager() {
+        return resourcesManager;
+    }
+
+    public UsersManagerApi getUsersManager() {
+        return usersManager;
+    }
+
+    public UtilsApi getUtils() {
+        return utils;
+    }
+
+    public VosManagerApi getVosManager() {
+        return vosManager;
+    }
+
+    public ServicesManagerApi getServicesManager() {
+        return servicesManager;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -112,12 +112,12 @@
 		</dependency>
 		-->
 
-		<dependency>
-        	<groupId>cz.metacentrum.perun</groupId>
-        	<artifactId>perun-openapi</artifactId>
-        	<version>${perun.version}</version>
-		</dependency>
-		
+        <dependency>
+            <groupId>com.evolveum.polygon</groupId>
+            <artifactId>connector-perun-rpc</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+
 		<dependency>
     	     <groupId>org.springframework</groupId>
    	    	 <artifactId>spring-web</artifactId>

--- a/src/main/java/cz/metacentrum/perun/polygon/connector/ObjectSearchBase.java
+++ b/src/main/java/cz/metacentrum/perun/polygon/connector/ObjectSearchBase.java
@@ -29,7 +29,7 @@ import org.identityconnectors.framework.common.objects.filter.NotFilter;
 import org.identityconnectors.framework.common.objects.filter.OrFilter;
 import org.identityconnectors.framework.common.objects.filter.StartsWithFilter;
 
-import cz.metacentrum.perun.openapi.PerunRPC;
+import cz.metacentrum.perun.polygon.connector.rpc.openapi.PerunRPC;
 
 public abstract class ObjectSearchBase implements ObjectSearch {
 
@@ -199,7 +199,7 @@ public abstract class ObjectSearchBase implements ObjectSearch {
 		return query;
 	}
 
-	protected Attribute createAttribute(cz.metacentrum.perun.openapi.model.Attribute attr) {
+	protected Attribute createAttribute(cz.metacentrum.perun.polygon.connector.rpc.openapi.model.Attribute attr) {
 		AttributeBuilder ab = new AttributeBuilder();
 		ab.setName(SchemaAdapterBase.getAttributeName(attr));
 		switch(attr.getType()) {

--- a/src/main/java/cz/metacentrum/perun/polygon/connector/PerunRPCConnector.java
+++ b/src/main/java/cz/metacentrum/perun/polygon/connector/PerunRPCConnector.java
@@ -35,7 +35,7 @@ import org.identityconnectors.framework.spi.operations.SchemaOp;
 import org.identityconnectors.framework.spi.operations.SearchOp;
 import org.identityconnectors.framework.spi.operations.TestOp;
 
-import cz.metacentrum.perun.openapi.PerunRPC;
+import cz.metacentrum.perun.polygon.connector.rpc.openapi.PerunRPC;
 
 /**
  * @author michal.vocu@gmail.com

--- a/src/main/java/cz/metacentrum/perun/polygon/connector/SchemaAdapterBase.java
+++ b/src/main/java/cz/metacentrum/perun/polygon/connector/SchemaAdapterBase.java
@@ -6,9 +6,9 @@ import org.identityconnectors.common.logging.Log;
 import org.identityconnectors.framework.common.objects.AttributeInfoBuilder;
 import org.identityconnectors.framework.common.objects.ObjectClassInfoBuilder;
 
-import cz.metacentrum.perun.openapi.PerunRPC;
-import cz.metacentrum.perun.openapi.model.Attribute;
-import cz.metacentrum.perun.openapi.model.AttributeDefinition;
+import cz.metacentrum.perun.polygon.connector.rpc.openapi.PerunRPC;
+import cz.metacentrum.perun.polygon.connector.rpc.openapi.model.Attribute;
+import cz.metacentrum.perun.polygon.connector.rpc.openapi.model.AttributeDefinition;
 
 public abstract class SchemaAdapterBase implements SchemaAdapter {
 

--- a/src/main/java/cz/metacentrum/perun/polygon/connector/UserExtSchemaAdapter.java
+++ b/src/main/java/cz/metacentrum/perun/polygon/connector/UserExtSchemaAdapter.java
@@ -7,7 +7,7 @@ import org.identityconnectors.framework.common.objects.Name;
 import org.identityconnectors.framework.common.objects.ObjectClassInfoBuilder;
 import org.identityconnectors.framework.common.objects.Uid;
 
-import cz.metacentrum.perun.openapi.PerunRPC;
+import cz.metacentrum.perun.polygon.connector.rpc.openapi.PerunRPC;
 
 public class UserExtSchemaAdapter extends SchemaAdapterBase {
 

--- a/src/main/java/cz/metacentrum/perun/polygon/connector/UserSchemaAdapter.java
+++ b/src/main/java/cz/metacentrum/perun/polygon/connector/UserSchemaAdapter.java
@@ -7,7 +7,7 @@ import org.identityconnectors.framework.common.objects.Name;
 import org.identityconnectors.framework.common.objects.ObjectClassInfoBuilder;
 import org.identityconnectors.framework.common.objects.Uid;
 
-import cz.metacentrum.perun.openapi.PerunRPC;
+import cz.metacentrum.perun.polygon.connector.rpc.openapi.PerunRPC;
 
 public class UserSchemaAdapter extends SchemaAdapterBase {
 

--- a/src/main/java/cz/metacentrum/perun/polygon/connector/UserSearch.java
+++ b/src/main/java/cz/metacentrum/perun/polygon/connector/UserSearch.java
@@ -17,11 +17,11 @@ import org.identityconnectors.framework.common.objects.filter.EqualsIgnoreCaseFi
 import org.identityconnectors.framework.common.objects.filter.Filter;
 import org.identityconnectors.framework.spi.SearchResultsHandler;
 
-import cz.metacentrum.perun.openapi.PerunRPC;
-import cz.metacentrum.perun.openapi.model.Attribute;
-import cz.metacentrum.perun.openapi.model.RichUser;
-import cz.metacentrum.perun.openapi.model.User;
-import cz.metacentrum.perun.openapi.model.UserExtSource;
+import cz.metacentrum.perun.polygon.connector.rpc.openapi.PerunRPC;
+import cz.metacentrum.perun.polygon.connector.rpc.openapi.model.Attribute;
+import cz.metacentrum.perun.polygon.connector.rpc.openapi.model.RichUser;
+import cz.metacentrum.perun.polygon.connector.rpc.openapi.model.User;
+import cz.metacentrum.perun.polygon.connector.rpc.openapi.model.UserExtSource;
 
 public class UserSearch extends ObjectSearchBase {
 

--- a/src/main/java/cz/metacentrum/perun/polygon/connector/VoMemberSchemaAdapter.java
+++ b/src/main/java/cz/metacentrum/perun/polygon/connector/VoMemberSchemaAdapter.java
@@ -7,7 +7,7 @@ import org.identityconnectors.framework.common.objects.Name;
 import org.identityconnectors.framework.common.objects.ObjectClassInfoBuilder;
 import org.identityconnectors.framework.common.objects.Uid;
 
-import cz.metacentrum.perun.openapi.PerunRPC;
+import cz.metacentrum.perun.polygon.connector.rpc.openapi.PerunRPC;
 
 public class VoMemberSchemaAdapter extends SchemaAdapterBase implements SchemaAdapter {
 

--- a/src/main/java/cz/metacentrum/perun/polygon/connector/VoSchemaAdapter.java
+++ b/src/main/java/cz/metacentrum/perun/polygon/connector/VoSchemaAdapter.java
@@ -7,7 +7,7 @@ import org.identityconnectors.framework.common.objects.Name;
 import org.identityconnectors.framework.common.objects.ObjectClassInfoBuilder;
 import org.identityconnectors.framework.common.objects.Uid;
 
-import cz.metacentrum.perun.openapi.PerunRPC;
+import cz.metacentrum.perun.polygon.connector.rpc.openapi.PerunRPC;
 
 public class VoSchemaAdapter extends SchemaAdapterBase implements SchemaAdapter {
 

--- a/src/main/java/cz/metacentrum/perun/polygon/connector/VoSearch.java
+++ b/src/main/java/cz/metacentrum/perun/polygon/connector/VoSearch.java
@@ -1,11 +1,8 @@
 package cz.metacentrum.perun.polygon.connector;
 
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.identityconnectors.common.logging.Log;
-import org.identityconnectors.framework.common.objects.AttributeBuilder;
 import org.identityconnectors.framework.common.objects.AttributeUtil;
 import org.identityconnectors.framework.common.objects.ConnectorObjectBuilder;
 import org.identityconnectors.framework.common.objects.ObjectClass;
@@ -18,11 +15,9 @@ import org.identityconnectors.framework.common.objects.filter.EqualsIgnoreCaseFi
 import org.identityconnectors.framework.common.objects.filter.Filter;
 import org.identityconnectors.framework.spi.SearchResultsHandler;
 
-import cz.metacentrum.perun.openapi.PerunRPC;
-import cz.metacentrum.perun.openapi.model.Attribute;
-import cz.metacentrum.perun.openapi.model.RichUser;
-import cz.metacentrum.perun.openapi.model.User;
-import cz.metacentrum.perun.openapi.model.Vo;
+import cz.metacentrum.perun.polygon.connector.rpc.openapi.PerunRPC;
+import cz.metacentrum.perun.polygon.connector.rpc.openapi.model.Attribute;
+import cz.metacentrum.perun.polygon.connector.rpc.openapi.model.Vo;
 
 public class VoSearch extends ObjectSearchBase implements ObjectSearch {
 


### PR DESCRIPTION
* Add new maven module which is used to generate java library to communicate with the perun RPC. The
library is generated from the `openapi.yml` specification from the `perun` github repository and
from the `master` branch.